### PR TITLE
term.c: define CMSPAR when a specific termios.h doesn't do it

### DIFF
--- a/term.c
+++ b/term.c
@@ -34,6 +34,14 @@
 #include <errno.h>
 #include <unistd.h>
 #include <termios.h>
+
+/* glibc for MIPS has its own bits/termios.h which does not define
+ * CMSPAR, so we use the value from the generic bits/termios.h
+ */
+#ifndef CMSPAR
+#define CMSPAR 010000000000
+#endif
+
 #ifdef __linux__
 #include <sys/ioctl.h>
 #endif


### PR DESCRIPTION
CMSPAR is defined by bits/termios.h, and glibc has two flavours of it: a
generic one and an architecture-specific one. glibc will install the
architecture-specific one if it exists, otherwise it will install the
generic one. Only Alpha, MIPS, PPC and Sparc have their own
bits/termios.h.

The generic bits/termios.h, as well as the Alpha, PPC and Sparc flavours
do define CMSPAR. However, the MIPS flavour does not define it.

Define CMSPAR to the value from the generic value, which is also the
value known to the Linux kernel for MIPS.

Patch inspired by:

  http://git.buildroot.net/buildroot/commit/?id=78cd32631e959e04b1a2f18be7b0757e21482438

Signed-off-by: Vicente Olivert Riera <Vincent.Riera@imgtec.com>