### PR TITLE
Add command to toggle RTS

### DIFF
--- a/picocom.1.md
+++ b/picocom.1.md
@@ -62,7 +62,7 @@ here.
 
 **C-q**
 
-:   Quit the program _without_ reseting the serial port, regardless of
+:   Quit the program _without_ resetting the serial port, regardless of
     the **--noreset** option.
 
 **C-p**
@@ -78,6 +78,7 @@ here.
 
 :   Toggle the RTS line. If RTS is up, then lower it. If it is down,
     then raise it. Not supported if the flow control mode is RTS/CTS.
+    Only supported in Linux.
 
 **C-backslash**
 
@@ -300,7 +301,7 @@ the same, only a single value is shown. Example:
 
     *** baud: 9600
 
-This behavioir was intriduced in picocom 2.0. Older releases displayed
+This behavior was introduced in picocom 2.0. Older releases displayed
 only the option values, not the actual serial-port settings
 corresponding to them.
 
@@ -321,7 +322,7 @@ programs for this purpose are:
     
 The name of, and the command-line options to, the program to be used
 for transmitting files are given by the **--send-cmd**
-option. Similarly the program to receive files, and its argumets, are
+option. Similarly the program to receive files, and its arguments, are
 given by the **--receive-cmd** option. For example, in order to start
 a picocom session that uses **sz(1)** to transmit files, and **rz(1)**
 to receive files, you have to say something like this:
@@ -348,7 +349,7 @@ with support for the linenoise library. Pressing **C-c** at this
 prompt will cancel the file transfer command and return to normal
 picocom operation. After entering a filename (and / or additional
 transmission or reception program arguments) and assuming you have not
-canceled the operation by pressing **C-c**, picocom will start the the
+canceled the operation by pressing **C-c**, picocom will start the
 external program as specified by the **--send-cmd**, or
 **--receive-cmd** option, and with any filenames and additional
 arguments you may have supplied. The standard input and output of the
@@ -365,7 +366,7 @@ the serial port.
 # INPUT, OUTPUT, AND ECHO MAPPING
 
 Using the **--imap**, **--omap**, and **--emap** options you can make
-picocom map (tranlate, replace) certain special characters after being
+picocom map (translate, replace) certain special characters after being
 read from the serial port (with **--imap**), before being written to
 the serial port (with **--omap**), and before being locally echoed to
 the terminal (standard output) if local echo is enabled (with
@@ -387,7 +388,7 @@ For example the command:
 
 will: 
 
-- Replace every CR (carriage return, 0x0d) caracter with LF (line
+- Replace every CR (carriage return, 0x0d) character with LF (line
   feed, 0x0a) and every DEL (delete, 0x7f) character with BS
   (backspace, 0x08) before writing it to the serial port.
 

--- a/picocom.1.md
+++ b/picocom.1.md
@@ -64,7 +64,7 @@ here.
 
 :   Quit the program _without_ reseting the serial port, regardless of
     the **--noreset** option.
-	
+
 **C-p**
 
 :   Pulse the DTR line. Lower it for 1 sec, and then raise it again.
@@ -73,6 +73,11 @@ here.
 
 :   Toggle the DTR line. If DTR is up, then lower it. If it is down,
     then raise it.
+
+**C-g**
+
+:   Toggle the RTS line. If RTS is up, then lower it. If it is down,
+    then raise it. Not supported if the flow control mode is RTS/CTS.
 
 **C-backslash**
 
@@ -83,7 +88,7 @@ here.
 
 **C-b**
 
-:   Set baurdate. Prompts you to enter a baudrate numerically (in bps)
+:   Set baudrate. Prompts you to enter a baudrate numerically (in bps)
     and configures the serial port accordingly.
 
 **C-u**

--- a/term.c
+++ b/term.c
@@ -1446,7 +1446,7 @@ term_lower_dtr(int fd)
 int
 term_raise_rts(int fd)
 {
-	int rval, r, i;
+	int rval, i;
 
 	rval = 0;
 
@@ -1460,6 +1460,7 @@ term_raise_rts(int fd)
 
 #ifdef __linux__
 		{
+			int r;
 			int opins = TIOCM_RTS;
 
 			r = ioctl(fd, TIOCMBIS, &opins);
@@ -1470,13 +1471,8 @@ term_raise_rts(int fd)
 			}
 		}
 #else
-		r = tcsetattr(fd, TCSANOW, &term.currtermios[i]);
-		if ( r < 0 ) {
-			/* FIXME: perhaps try to update currtermios */
-			term_errno = TERM_ESETATTR;
-			rval = -1;
-			break;
-		}
+		term_errno = TERM_ERTSUP;
+		rval = -1;
 #endif /* of __linux__ */
 	} while (0);
 
@@ -1488,7 +1484,7 @@ term_raise_rts(int fd)
 int
 term_lower_rts(int fd)
 {
-	int rval, r, i;
+	int rval, i;
 
 	rval = 0;
 
@@ -1502,6 +1498,7 @@ term_lower_rts(int fd)
 
 #ifdef __linux__
 		{
+			int r;
 			int opins = TIOCM_RTS;
 
 			r = ioctl(fd, TIOCMBIC, &opins);
@@ -1512,27 +1509,8 @@ term_lower_rts(int fd)
 			}
 		}
 #else
-		{
-			struct termios tio;
-
-			r = tcgetattr(fd, &tio);
-			if ( r < 0 ) {
-				term_errno = TERM_EGETATTR;
-				rval = -1;
-				break;
-			}
-			term.currtermios[i] = tio;
-			
-			cfsetospeed(&tio, B0);
-			cfsetispeed(&tio, B0);
-			
-			r = tcsetattr(fd, TCSANOW, &tio);
-			if ( r < 0 ) {
-				term_errno = TERM_ESETATTR;
-				rval = -1;
-				break;
-			}
-		}
+		term_errno = TERM_ERTSDOWN;
+		rval = -1;
 #endif /* of __linux__ */
 	} while (0);
 	

--- a/term.h
+++ b/term.h
@@ -60,6 +60,8 @@
  * F term_pulse_dtr - pulse the DTR line a device
  * F term_lower_dtr - lower the DTR line of a device
  * F term_raise_dtr - raise the DTR line of a device
+ * F term_lower_rts - lower the RTS line of a device
+ * F term_raise_rts - raise the RTS line of a device
  * F term_get_mctl - Get modem control signals status
  * F term_drain - drain the output from the terminal buffer
  * F term_flush - discard terminal input and output queue contents
@@ -142,7 +144,9 @@ enum term_errno_e {
 	TERM_EDTRUP,
 	TERM_EMCTL,
 	TERM_EDRAIN,     /* see errno */
-	TERM_EBREAK
+	TERM_EBREAK,
+	TERM_ERTSDOWN,
+	TERM_ERTSUP
 };
 
 /* E parity_e
@@ -604,6 +608,24 @@ int term_lower_dtr (int fd);
  * Returns negative on failure, non negative on success.
  */
 int term_raise_dtr (int fd);
+
+/* F term_lower_rts
+ *
+ * Lowers the RTS line of the device associated with the managed
+ * filedes "fd".
+ *
+ * Returns negative on failure, non negative on success.
+ */
+int term_lower_rts (int fd);
+
+/* F term_raise_rts
+ *
+ * Raises the RTS line of the device associated with the managed
+ * filedes "fd".
+ *
+ * Returns negative on failure, non negative on success.
+ */
+int term_raise_rts (int fd);
 
 /* F term_get_mctl
  *


### PR DESCRIPTION
Toggle RTS: this is a new command that parallels the command for toggling DTR. Toggling RTS is useful for troubleshooting flow control signals. It is also useful for embedded hardware which is configured so RTS controls an external component (such as a relay, FET, or enable line). Toggling RTS is supported if the flow control mode is none or xon/xoff (not supported under RTS/CTS flow control for obvious reasons). The TIOCMBIC and TIOCMBIS ioctls() on TIOCM_RTS under Linux still succeed if the flow control is RTS/CTS, but the actual state on the RTS line does not change.