### PR TITLE
fixed manual rts & dtr control for OSX

### DIFF
--- a/picocom.1.md
+++ b/picocom.1.md
@@ -78,7 +78,7 @@ here.
 
 :   Toggle the RTS line. If RTS is up, then lower it. If it is down,
     then raise it. Not supported if the flow control mode is RTS/CTS.
-    Only supported in Linux.
+    Only supported in Linux and OSX.
 
 **C-backslash**
 
@@ -276,13 +276,13 @@ Picocom accepts the following command-line options.
 :   Lower the RTS control signal after opening the serial port (by
     default RTS is raised after open implicitely by the OS). Only
     supported when flow-control mode is not set to RTS/CTS, ignored
-    otherwise. Only supported in Linux.
+    otherwise. Only supported in Linux and OSX.
 
 **--lower-dtr**
 
 :   Lower the DTR control signal after opening the serial port (by
     default DTR is raised after open implicitely by the OS).
-    Only supported in Linux.
+    Only supported in Linux and OSX.
 
 **--help** | **-h**
 

--- a/term.c
+++ b/term.c
@@ -52,7 +52,7 @@
 #define CMSPAR 0
 #endif
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <sys/ioctl.h>
 #endif
 
@@ -1283,7 +1283,7 @@ term_pulse_dtr (int fd)
 			break;
 		}
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		{
 			int opins = TIOCM_DTR;
 
@@ -1335,7 +1335,7 @@ term_pulse_dtr (int fd)
 				break;
 			}
 		}
-#endif /* of __linux__ */
+#endif /* of __linux__ or __APPLE__ */
 			
 	} while (0);
 
@@ -1359,7 +1359,7 @@ term_raise_dtr(int fd)
 			break;
 		}
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		{
 			int opins = TIOCM_DTR;
 
@@ -1378,7 +1378,7 @@ term_raise_dtr(int fd)
 			rval = -1;
 			break;
 		}
-#endif /* of __linux__ */
+#endif /* of __linux__ or __APPLE__ */
 	} while (0);
 
 	return rval;
@@ -1402,7 +1402,7 @@ term_lower_dtr(int fd)
 			break;
 		}
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		{
 			int opins = TIOCM_DTR;
 
@@ -1435,7 +1435,7 @@ term_lower_dtr(int fd)
 				break;
 			}
 		}
-#endif /* of __linux__ */
+#endif /* of __linux__ or __APPLE__ */
 	} while (0);
 	
 	return rval;
@@ -1458,7 +1458,7 @@ term_raise_rts(int fd)
 			break;
 		}
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		{
 			int r;
 			int opins = TIOCM_RTS;
@@ -1473,7 +1473,7 @@ term_raise_rts(int fd)
 #else
 		term_errno = TERM_ERTSUP;
 		rval = -1;
-#endif /* of __linux__ */
+#endif /* of __linux__ or __APPLE__ */
 	} while (0);
 
 	return rval;
@@ -1496,7 +1496,7 @@ term_lower_rts(int fd)
 			break;
 		}
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		{
 			int r;
 			int opins = TIOCM_RTS;
@@ -1511,7 +1511,7 @@ term_lower_rts(int fd)
 #else
 		term_errno = TERM_ERTSDOWN;
 		rval = -1;
-#endif /* of __linux__ */
+#endif /* of __linux__ or __APPLE__ */
 	} while (0);
 	
 	return rval;
@@ -1533,7 +1533,7 @@ term_get_mctl (int fd)
 			break;
 		}
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		{ 
 			int r, pmctl;
 			
@@ -1552,7 +1552,7 @@ term_get_mctl (int fd)
 		}
 #else
 		mctl = MCTL_UNAVAIL;
-#endif
+#endif /* of __linux__ or __APPLE__ */
 	} while(0);
 
 	return mctl;


### PR DESCRIPTION
Before this change, the behaviour on OSX was as follows:
- C-a C-t always shows `*** DTR: up ***` and don’t changes the signal level (DTR stays raised).
- C-a C-p shows: `*** pulse DTR ***`, `*** FAILED`
- C-a C-g always shows `*** RTS: down ***` and don’t changes the signal level (RTS stays raised).

With this PR, all the the 3 above mentioned commands working as expected and also the command line options `--lower-rts` and `--lower-dtr` are working now.



