### PR TITLE
Improved baudrate support for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,41 +36,13 @@ CPPFLAGS += -DHISTFILE=\"$(HISTFILE)\" \
 OBJS += linenoise-1.0/linenoise.o
 linenoise-1.0/linenoise.o : linenoise-1.0/linenoise.c linenoise-1.0/linenoise.h
 
-## Detect host machine / OS and store it into a make variable named "HOST_SYSTEM" for later use
-OS ?=
-OSTYPE ?=
-ifeq ($(OS),Windows_NT)
-  ifeq ($(OSTYPE),cygwin)
-    HOST_SYSTEM := Cygwin
-  else
-    HOST_SYSTEM := Windows
-  endif  
-else
-  UNAME_S := $(shell uname -s)
-  ifeq ($(UNAME_S),Linux)
-    HOST_SYSTEM := Linux
-  else ifeq ($(UNAME_S),Darwin)
-    HOST_SYSTEM := Darwin
-  else
-    $(warning Warning: Unknown host system '$(UNAME_S)')
-    HOST_SYSTEM := Unknown
-  endif
-endif
+## Comment this in to enable custom baudrate support for OSX (Tiger and above)
+#CPPFLAGS += -DUSE_CUSTOM_BAUD
 
-## Set USE_CUSTOM_BAUD=1 to enable custom baudrate support.
-## Currently works *only* with Linux (kernels > 2.6) and OSX (Tiger and above)
-USE_CUSTOM_BAUD ?=
-ifeq ($(USE_CUSTOM_BAUD),1)
-  ifeq ($(HOST_SYSTEM),Linux)
-    CPPFLAGS += -DUSE_CUSTOM_BAUD
-    OBJS += termios2.o
-    termios2.o : termios2.c termios2.h termbits2.h
-  else ifeq ($(HOST_SYSTEM),Darwin)
-    CPPFLAGS += -DUSE_CUSTOM_BAUD
-  else
-    $(warning Warning: Custom baudrates not supported for your platform, yet.)
-  endif
-endif
+## Comment this in to enable custom baudrate support for Linux (kernels > 2.6)
+#CPPFLAGS += -DUSE_CUSTOM_BAUD
+#OBJS += termios2.o
+#termios2.o : termios2.c termios2.h termbits2.h
 
 ## Comment this IN to remove help strings (saves ~ 4-6 Kb).
 #CPPFLAGS += -DNO_HELP

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,41 @@ CPPFLAGS += -DHISTFILE=\"$(HISTFILE)\" \
 OBJS += linenoise-1.0/linenoise.o
 linenoise-1.0/linenoise.o : linenoise-1.0/linenoise.c linenoise-1.0/linenoise.h
 
-## Comment these IN to enable custom baudrate support.
-## Currently works *only* with Linux (kernels > 2.6).
-#CPPFLAGS += -DUSE_CUSTOM_BAUD
-#OBJS += termios2.o
-#termios2.o : termios2.c termios2.h termbits2.h
+## Detect host machine / OS and store it into a make variable named "HOST_SYSTEM" for later use
+OS ?=
+OSTYPE ?=
+ifeq ($(OS),Windows_NT)
+  ifeq ($(OSTYPE),cygwin)
+    HOST_SYSTEM := Cygwin
+  else
+    HOST_SYSTEM := Windows
+  endif  
+else
+  UNAME_S := $(shell uname -s)
+  ifeq ($(UNAME_S),Linux)
+    HOST_SYSTEM := Linux
+  else ifeq ($(UNAME_S),Darwin)
+    HOST_SYSTEM := Darwin
+  else
+    $(warning Warning: Unknown host system '$(UNAME_S)')
+    HOST_SYSTEM := Unknown
+  endif
+endif
+
+## Set USE_CUSTOM_BAUD=1 to enable custom baudrate support.
+## Currently works *only* with Linux (kernels > 2.6) and OSX (Tiger and above)
+USE_CUSTOM_BAUD ?=
+ifeq ($(USE_CUSTOM_BAUD),1)
+  ifeq ($(HOST_SYSTEM),Linux)
+    CPPFLAGS += -DUSE_CUSTOM_BAUD
+    OBJS += termios2.o
+    termios2.o : termios2.c termios2.h termbits2.h
+  else ifeq ($(HOST_SYSTEM),Darwin)
+    CPPFLAGS += -DUSE_CUSTOM_BAUD
+  else
+    $(warning Warning: Custom baudrates not supported for your platform, yet.)
+  endif
+endif
 
 ## Comment this IN to remove help strings (saves ~ 4-6 Kb).
 #CPPFLAGS += -DNO_HELP

--- a/picocom.c
+++ b/picocom.c
@@ -1616,6 +1616,10 @@ main(int argc, char *argv[])
 	init_history();
 #endif
 
+	r = term_get_baudrate(tty_fd, NULL);
+	if ( r != opts.baud )
+		fd_printf(STO, "WARNING: Desired baudrate is %d but applied baudrate is %d; this might depend upon your OS and/or hardware limitations.\r\n\r\n", opts.baud, r);
+
 #ifndef NO_HELP
 	fd_printf(STO, "Type [C-%c] [C-%c] to see available commands\r\n\r\n",
 			  KEYC(opts.escape), KEYC(KEY_HELP));

--- a/picocom.c
+++ b/picocom.c
@@ -1624,10 +1624,6 @@ main(int argc, char *argv[])
 	init_history();
 #endif
 
-	r = term_get_baudrate(tty_fd, NULL);
-	if ( r != opts.baud )
-		fd_printf(STO, "WARNING: Desired baudrate is %d but applied baudrate is %d; this might depend upon your OS and/or hardware limitations.\r\n\r\n", opts.baud, r);
-
 #ifndef NO_HELP
 	fd_printf(STO, "Type [C-%c] [C-%c] to see available commands\r\n\r\n",
 			  KEYC(opts.escape), KEYC(KEY_HELP));

--- a/term.c
+++ b/term.c
@@ -161,6 +161,48 @@ term_perror (const char *prefix)
 }
 
 /***************************************************************************/
+/* OSX termios.h unfortunately just provides constants for
+ * baudrates up to 230k, so we add the missing constants here.             */
+#if defined(__APPLE__)
+  #ifndef B460800
+    #define B460800   460800
+  #endif
+  #ifndef B500000
+    #define B500000   500000
+  #endif
+  #ifndef B576000
+    #define B576000   576000
+  #endif
+  #ifndef B921600
+    #define B921600   921600
+  #endif
+  #ifndef B1000000
+    #define B1000000 1000000
+  #endif
+  #ifndef B1152000
+    #define B1152000 1152000
+  #endif
+  #ifndef B1500000
+    #define B1500000 1500000
+  #endif
+  #ifndef B2000000
+    #define B2000000 2000000
+  #endif
+  #ifndef B2500000
+    #define B2500000 2500000
+  #endif
+  #ifndef B3000000
+    #define B3000000 3000000
+  #endif
+  #ifndef B3500000
+    #define B3500000 3500000
+  #endif
+  #ifndef B4000000
+    #define B4000000 4000000
+  #endif
+#endif
+
+/***************************************************************************/
 
 #define BNONE 0xFFFFFFFF
 

--- a/term.c
+++ b/term.c
@@ -56,7 +56,7 @@
 #include <sys/ioctl.h>
 #endif
 
-#ifdef USE_CUSTOM_BAUD
+#if defined(__linux__) && defined(USE_CUSTOM_BAUD)
 /* only works for linux, recent kernels */
 #include "termios2.h"
 #endif
@@ -200,7 +200,27 @@ term_perror (const char *prefix)
   #ifndef B4000000
     #define B4000000 4000000
   #endif
-#endif
+#endif /* __APPLE__ */
+
+/***************************************************************************/
+/* Custom baudrates support for OSX */
+#if defined(__APPLE__) && defined (USE_CUSTOM_BAUD)
+int cfsetospeed_custom(struct termios *tiop, int speed) {
+	return cfsetospeed(tiop, speed);
+}
+
+int cfsetispeed_custom(struct termios *tiop, int speed) {
+	return cfsetispeed(tiop, speed);
+}
+
+int cfgetospeed_custom(struct termios *tiop) {
+	return cfgetospeed(tiop);
+}
+
+int cfgetispeed_custom(struct termios *tiop) {
+	return cfgetispeed(tiop);
+}
+#endif /* __APPLE__ && USE_CUSTOM_BAUD */
 
 /***************************************************************************/
 


### PR DESCRIPTION
- Added higher baudrates. OSX termios.h unfortunately just provides constants for baudrates up to 230k, so I'd added the missing constants. Tested with some Ftdi adapters.
- Added custom baudrate support for OSX.
- Added warning if applied baudrate differs from opts.baud on startup. This helps to reduce confusion, especially when playing around with non standard baudrates.