### PR TITLE
Makefile: use environment set variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 
 VERSION = 2.3a
 
-#CC = gcc
-CPPFLAGS = -DVERSION_STR=\"$(VERSION)\"
-CFLAGS = -Wall -g
+#CC ?= gcc
+CPPFLAGS += -DVERSION_STR=\"$(VERSION)\"
+CFLAGS += -Wall -g
 
 LD = $(CC)
-LDFLAGS = -g
-LDLIBS =
+LDFLAGS ?= -g
+LDLIBS ?=
 
 all: picocom
 OBJS =


### PR DESCRIPTION
Allow extending the toolchain related variables from the environment. This is
particularly useful when cross compiling, since it allows adding target
specific parameters.

Leave LD alone since it is used to link the final picocom binary. The default
ld linker can't do that without explicitly specifying the C library.