### PR TITLE
Changed when to enable custom baud by default (#84)

### DIFF
--- a/custbaud.h
+++ b/custbaud.h
@@ -41,9 +41,20 @@
 #endif /* of arch */
 #endif /* of version */
 
-#elif defined (__APPLE__)
+#elif defined (__APPLE__) && defined(__MACH__)
 
-/* ?? Maybe enable by-default for specific versions ?? */
+#include <AvailabilityMacros.h>
+#include <TargetConditionals.h>
+#if TARGET_IPHONE_SIMULATOR
+/* Do not enable by default for iOS in Xcode simulator */
+#elif TARGET_OS_IPHONE
+/* Do not enable by default for iOS until it has been tested */
+#elif TARGET_OS_MAC
+/* Enable by-default for macOS / OSX >= 10.4 (Tiger) */
+#ifndef USE_CUSTOM_BAUD
+#define USE_CUSTOM_BAUD
+#endif
+#endif /* of TARGET_OS_... */
 #define CUSTOM_BAUD_HEAD "custbaud_bsd.h"
 
 #elif defined (__NetBSD__)


### PR DESCRIPTION
For Apple:
- enable by default for macOS / OSX
- do not enable by default for iOS

Have not found a way to check for OSX version on preprocessor level.