### PR TITLE
Add default settings at compile time

### DIFF
--- a/default_settings.h
+++ b/default_settings.h
@@ -1,0 +1,116 @@
+#ifndef DEFAULT_SETTINGS_H
+#define DEFAULT_SETTINGS_H
+
+#ifndef DEF_PORT
+#define DEF_PORT "/dev/ttyS0"
+#endif
+
+#ifndef DEF_BAUD
+#define DEF_BAUD 9600
+#endif
+
+#ifndef DEF_FLOW
+#define DEF_FLOW FC_NONE
+#endif
+
+#ifndef DEF_PARITY
+#define DEF_PARITY P_NONE
+#endif
+
+#ifndef DEF_DATABITS
+#define DEF_DATABITS 8
+#endif
+
+#ifndef DEF_STOPBITS
+#define DEF_STOPBITS 1
+#endif
+
+#ifndef DEF_LECHO
+#define DEF_LECHO 0
+#endif
+
+#ifndef DEF_NOINIT
+#define DEF_NOINIT 0
+#endif
+
+#ifndef DEF_NORESET
+#define DEF_NORESET 0
+#endif
+
+#ifndef DEF_HANGUP
+#define DEF_HANGUP 0
+#endif
+
+#if defined (UUCP_LOCK_DIR) || defined (USE_FLOCK)
+
+#ifndef DEF_NOLOCK
+#define DEF_NOLOCK 0
+#endif
+
+#endif
+
+#ifndef DEF_ESCAPE
+#define DEF_ESCAPE 'a'
+#endif
+
+#ifndef DEF_NOESCAPE
+#define DEF_NOESCAPE 0
+#endif
+
+#ifndef DEF_SEND_CMD
+#define DEF_SEND_CMD "sz -vv"
+#endif
+
+#ifndef DEF_RECEIVE_CMD
+#define DEF_RECEIVE_CMD "rz -vv"
+#endif
+
+#ifndef DEF_IMAP
+#define DEF_IMAP M_I_DFL
+#endif
+
+#ifndef DEF_OMAP
+#define DEF_OMAP M_O_DFL
+#endif
+
+#ifndef DEF_EMAP
+#define DEF_EMAP M_E_DFL
+#endif
+
+#ifndef DEF_LOG_FILENAME
+#define DEF_LOG_FILENAME NULL
+#endif
+
+#ifndef DEF_INITSTRING
+#define DEF_INITSTRING NULL
+#endif
+
+#ifndef DEF_EXIT_AFTER
+#define DEF_EXIT_AFTER -1
+#endif
+
+#ifndef DEF_EXIT
+#define DEF_EXIT 0
+#endif
+
+#ifndef DEF_LOWER_RTS
+#define DEF_LOWER_RTS 0
+#endif
+
+#ifndef DEF_LOWER_DTR
+#define DEF_LOWER_DTR 0
+#endif
+
+#ifndef DEF_RAISE_RTS
+#define DEF_RAISE_RTS 0
+#endif
+
+#ifndef DEF_RAISE_DTR
+#define DEF_RAISE_DTR 0
+#endif
+
+#ifndef DEF_QUIET
+#define DEF_QUIET 0
+#endif
+
+#endif

--- a/picocom.c
+++ b/picocom.c
@@ -56,7 +56,7 @@
 #endif
 
 #include "custbaud.h"
-
+#include "default_settings.h"
 /**********************************************************************/
 
 /* parity modes names */
@@ -218,34 +218,34 @@ struct {
     int quiet;
 } opts = {
     .port = NULL,
-    .baud = 9600,
-    .flow = FC_NONE,
-    .parity = P_NONE,
-    .databits = 8,
-    .stopbits = 1,
-    .lecho = 0,
-    .noinit = 0,
-    .noreset = 0,
-    .hangup = 0,
+    .baud = DEF_BAUD,
+    .flow = DEF_FLOW,
+    .parity = DEF_PARITY,
+    .databits = DEF_DATABITS,
+    .stopbits = DEF_STOPBITS,
+    .lecho = DEF_LECHO,
+    .noinit = DEF_NOINIT,
+    .noreset = DEF_NORESET,
+    .hangup = DEF_HANGUP,
 #if defined (UUCP_LOCK_DIR) || defined (USE_FLOCK)
-    .nolock = 0,
+    .nolock = DEF_NOLOCK,
 #endif
-    .escape = CKEY('a'),
-    .noescape = 0,
-    .send_cmd = "sz -vv",
-    .receive_cmd = "rz -vv -E",
-    .imap = M_I_DFL,
-    .omap = M_O_DFL,
-    .emap = M_E_DFL,
-    .log_filename = NULL,
-    .initstring = NULL,
-    .exit_after = -1,
-    .exit = 0,
-    .lower_rts = 0,
-    .lower_dtr = 0,
-    .raise_rts = 0,
-    .raise_dtr = 0,
-    .quiet = 0
+    .escape = CKEY(DEF_ESCAPE),
+    .noescape = DEF_NOESCAPE,
+    .send_cmd = DEF_SEND_CMD,
+    .receive_cmd = DEF_RECEIVE_CMD,
+    .imap = DEF_IMAP,
+    .omap = DEF_OMAP,
+    .emap = DEF_EMAP,
+    .log_filename = DEF_LOG_FILENAME,
+    .initstring = DEF_INITSTRING,
+    .exit_after = DEF_EXIT_AFTER,
+    .exit = DEF_EXIT,
+    .lower_rts = DEF_LOWER_RTS,
+    .lower_dtr = DEF_LOWER_DTR,
+    .raise_rts = DEF_RAISE_RTS,
+    .raise_dtr = DEF_RAISE_DTR,
+    .quiet = DEF_QUIET
 };
 
 int sig_exit = 0;
@@ -1926,11 +1926,10 @@ parse_args(int argc, char *argv[])
     if ( opts.exit ) opts.exit_after = -1;
 
     if ( (argc - optind) < 1) {
-        fprintf(stderr, "No port given\n");
-        fprintf(stderr, "Run with '--help'.\n");
-        exit(EXIT_FAILURE);
+        opts.port = strdup(DEF_PORT);
+    } else {
+        opts.port = strdup(argv[optind++]);
     }
-    opts.port = strdup(argv[optind++]);
     if ( ! opts.port ) {
         fprintf(stderr, "Out of memory\n");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Gentlemen. I moved the default values from `picocom.c` to a separate header file, `default_settings.h`. Please hear me out about how this is useful.

I connect to my embedded devices through USB serial. All devices in my environment are using 115200. Instead of typing "-b 115200 /dev/ttyUSB0" every time I launch picocom, I want the parameters burned into the binary.

Yes. I can simply change them in `picocom.c`, if I'm already familiar with this great project. But how about a random guy who's just looking for a terminal serial monitor? I doubt he is. Plus, having to manually download the source code and compile yourself is a bit inconvenient, especially for Gentoo users.

In fact, here in Gentoo, when you decided to install a package, you can tell your system how you want it. For example,

    emerge vlc

builds a common vlc, but

    USE=bluray emerge vlc

builds vlc with bluray support.

If picocom enables build-time configuration, we can build a customized picocom without even taking a glance of the code.

    make CFLAGS+=-DDEF_BAUD=115200

builds a picocom binary that sets the baud rate to 115200 unless told otherwise. We Gentoo users can further put this in our ebuild file so that we can install picocom with

    USE="baud_115200 port_ttyUSB0" emerge picocom

No need to mess with [custom repository](https://wiki.gentoo.org/wiki/Handbook:AMD64/Portage/CustomTree#Defining_a_custom_repository). What a breeze!

BTW, with this merge, the error where the user launches picocom without specifying a port, will go away, because picocom always tries to open the pre-defined port.