### PR TITLE
Add custbaud.c to Android.mk

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -30,7 +30,8 @@ LOCAL_SRC_FILES := \
     term.c \
     fdio.c \
     split.c \
-    termios2.c
+    termios2.c \
+    custbaud.c
 
 LOCAL_CFLAGS += -DVERSION_STR=\"$(VERSION)\"
 


### PR DESCRIPTION
Android build is currently broken due to failure to include custbaud.c in source files in Android.mk.