### PR TITLE
Fix assertion with igncr when CR on input

### DIFF
--- a/picocom.c
+++ b/picocom.c
@@ -817,7 +817,7 @@ do_map (char *b, int map, char c)
         b[0] = c; n = 1;
     }
 
-    assert(n > 0 && n <= M_MAXMAP);
+    assert(n >= 0 && n <= M_MAXMAP);
 
     return n;
 }


### PR DESCRIPTION
I have discovered a problem with function `do_map`. When I run picocom with

`--imap igncr`

it fails with assertion with CR character on input which it should just ignore.

`do_map: Assertion 'n > 0 && n <= M_MAXMAP' failed.`

After bisecting the code, it was introduced by commit 50b8e6962cd60396686dd63e510fe4afa30f38b4

It seems that n is also valid for value 0, si this fix allow this value
