### PR TITLE
remove usleep

### DIFF
--- a/term.c
+++ b/term.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 #include <unistd.h>
 #include <termios.h>
 #ifdef USE_FLOCK
@@ -1614,7 +1615,10 @@ term_drain(int fd)
            the port is immediately reconfigured, even after a
            drain. (I guess, drain does not wait for everything to
            actually be transitted on the wire). */
-        if ( DRAIN_DELAY ) usleep(DRAIN_DELAY);
+        if ( DRAIN_DELAY ) {
+            struct timespec d = {0, DRAIN_DELAY * 1000};
+            nanosleep(&d, NULL);
+        }
 
     } while (0);
 
@@ -1666,7 +1670,10 @@ term_fake_flush(int fd)
             break;
         }
         /* see comment in term_drain */
-        if ( DRAIN_DELAY ) usleep(DRAIN_DELAY);
+        if ( DRAIN_DELAY ) {
+            struct timespec d = {0, DRAIN_DELAY * 1000};
+            nanosleep(&d, NULL);
+        }
         /* Reset flow-control to original setting. */
         r = tcsetattr(fd, TCSANOW, &term.currtermios[i]);
         if ( r < 0 ) {


### PR DESCRIPTION
usleep is removed in POSIX 2008.

Signed-off-by: Rosen Penev <rosenp@gmail.com>