### PR TITLE
Fix wrong assert when using --omap igncr, n=0 is valid value

### DIFF
--- a/picocom.c
+++ b/picocom.c
@@ -817,7 +817,7 @@ do_map (char *b, int map, char c)
         b[0] = c; n = 1;
     }
 
-    assert(n > 0 && n <= M_MAXMAP);
+    assert(n >= 0 && n <= M_MAXMAP);
 
     return n;
 }


### PR DESCRIPTION
On CR mapping (line 766) n=0 for igncr option. So the final assert (line 820) on do_map function should not fail. 