### PR TITLE
Fix typo about flag --exit-after (was: exit-aftrer)

### DIFF
--- a/picocom.1.md
+++ b/picocom.1.md
@@ -404,7 +404,7 @@ Picocom accepts the following command-line options.
     is system dependent. On most systems the signal is raised.
 
 
-**--exit-aftrer** | **-x**
+**--exit-after** | **-x**
 
 :   Exit picocom if it remains idle for the specified time (in
     milliseconds). Picocom is considered idle if: Nothing is read


### PR DESCRIPTION
Hi there,

Fixing a simple typo that I just stumbled across in the man page.  Hope this helps.

This PR isn't complete as I'm failing to generate documentation with pandoc; perhaps @npat-efault you can help me find the missing link?  I've run "make doc" and it looks like I am missing an unversioned ~/.pandoc/tmpl/manpage.html:
```
╭─pv at CHI-Linux-L-016 in ~/src/github.com/trickv/picocom on master✔
╰─± make doc
pandoc -s -t html \
    --template ~/.pandoc/tmpl/manpage.html \
    -c ~/.pandoc/css/normalize-noforms.css \
    -c ~/.pandoc/css/manpage.css \
    --self-contained \
    -Vversion="v3.2a" -Vdate="`date -I`" \
    -o picocom.1.html picocom.1.md
pandoc: /home/pv/.pandoc/tmpl/manpage.html: openBinaryFile: does not exist (No such file or directory)
make: *** [Makefile:79: picocom.1.html] Error 1
```