### PR TITLE
macOS: support high baud rate on Apple arm64 processor

### DIFF
--- a/custbaud.h
+++ b/custbaud.h
@@ -58,7 +58,7 @@
 #elif TARGET_OS_IPHONE
 /* Do not enable by default for iOS until it has been tested */
 #elif TARGET_OS_MAC
-#if defined (__i386__) || defined (__x86_64__)
+#if defined (__i386__) || defined (__x86_64__) || defined (__arm64__)
 /* Enable by-default for Intel Mac, macOS / OSX >= 10.4 (Tiger) */
 #ifndef USE_CUSTOM_BAUD
 #define USE_CUSTOM_BAUD


### PR DESCRIPTION
Signed-off-by: Jack Ma <jack@radxa.com>

Discussion here:

https://forum.radxa.com/t/macos-pi-4-e-s-working-1-5mbps-ttl-baudrate-with-picocom/8121