### PR TITLE
Allow limiting the serial output character rate

### DIFF
--- a/picocom.1
+++ b/picocom.1
@@ -502,6 +502,13 @@ port, is system dependent.
 On most systems the signal is raised.
 .RE
 .TP
+.B \f[B]\-\-rate\f[] | \f[B]\-R\f[]
+Defines the rate (characters per second) at which the input buffer is
+copied to the serial\-port.
+This may help to avoid buffer overruns if no flow control is available.
+.RS
+.RE
+.TP
 .B \f[B]\-\-exit\-aftrer\f[] | \f[B]\-x\f[]
 Exit picocom if it remains idle for the specified time (in
 milliseconds).

--- a/picocom.c
+++ b/picocom.c
@@ -1540,12 +1540,18 @@ loop(void)
         }
 
         if ( FD_ISSET(tty_fd, &wrset) ) {
+            int have_esc = 0;
+            int sz;
 
             /* write to port */
-            int sz;
             sz = (tty_q.len < tty_write_sz) ? tty_q.len : tty_write_sz;
             do {
-                if (tty_sleep.tv_sec | tty_sleep.tv_nsec) {
+
+                /* Escape sequences shall be delivered directly */
+                if (*tty_q.buff == '\x1b')
+                        have_esc = 1;
+
+                if (!have_esc && (tty_sleep.tv_sec | tty_sleep.tv_nsec)) {
                     nanosleep(&tty_sleep, NULL);
                     n = write(tty_fd, tty_q.buff, 1);
                 } else {


### PR DESCRIPTION
When no flow control is available buffer overruns may easily occur.
This patch introduces a command line parameter --rate | -R which allows to
limit the rate at which characters are written to the serial port.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>