### PR TITLE
add parameter to delay line transmission

### DIFF
--- a/picocom.1.md
+++ b/picocom.1.md
@@ -224,6 +224,15 @@ Picocom accepts the following command-line options.
 :   Defines the number of stop bits in every character. Must be one
     of: **1**, or **2**. (Default: **1**)
 
+**--line-delay** | **-L**
+
+:   Delays for the specified amount of time (in nanonseconds) after each
+    line sent. If you do not use any flow-control, this can help to
+    prevent lost characters due to buffer overruns when sending larger
+    blocks of data, e.g. when pasting text. Allowed range is from **0**
+    (disabling the feature) to **999999999** (nearly  1 second).
+    (Default: **0**)
+
 **--escape** | **-e**
 
 :   Defines the character that will make picocom enter command-mode

--- a/picocom.c
+++ b/picocom.c
@@ -37,6 +37,7 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <limits.h>
+#include <time.h>
 #ifdef USE_FLOCK
 #include <sys/file.h>
 #endif
@@ -216,6 +217,7 @@ struct {
     int raise_rts;
     int raise_dtr;
     int quiet;
+    struct timespec line_delay;
 } opts = {
     .port = NULL,
     .baud = 9600,
@@ -245,7 +247,8 @@ struct {
     .lower_dtr = 0,
     .raise_rts = 0,
     .raise_dtr = 0,
-    .quiet = 0
+    .quiet = 0,
+    .line_delay = { 0, 0 },
 };
 
 int sig_exit = 0;
@@ -1399,6 +1402,23 @@ enum le_reason {
     LE_SIGNAL
 };
 
+void *next_newline(void *p, int sz)
+{
+    void *nn = memchr(p, '\n', sz);
+    void *nr = memchr(p, '\r', sz);
+    if ( nn && nr ) {
+        if (nn - nr == 1)
+            return nn;
+        return (nn < nr) ? nn : nr;
+    } else if ( nn ) {
+        return nn;
+    } else if ( nr ) {
+        return nr;
+    } else {
+        return NULL;
+    }
+}
+
 enum le_reason
 loop(void)
 {
@@ -1537,6 +1557,12 @@ loop(void)
 
             int sz;
             sz = (tty_q.len < tty_write_sz) ? tty_q.len : tty_write_sz;
+            if (opts.line_delay.tv_nsec) {
+                unsigned char *nl = next_newline(tty_q.buff, sz);
+                if (nl) {
+                    sz = nl + 1 - tty_q.buff;
+                }
+            }
             do {
                 n = write(tty_fd, tty_q.buff, sz);
             } while ( n < 0 && errno == EINTR );
@@ -1545,6 +1571,11 @@ loop(void)
             if ( opts.lecho && opts.log_filename )
                 if ( writen_ni(log_fd, tty_q.buff, n) < n )
                     fatal("write to logfile failed: %s", strerror(errno));
+            if (opts.line_delay.tv_nsec) {
+                if (tty_q.buff[n-1] == '\r' || tty_q.buff[n-1] == '\n') {
+                    nanosleep(&opts.line_delay, NULL);
+                }
+            }
             memmove(tty_q.buff, tty_q.buff + n, tty_q.len - n);
             tty_q.len -= n;
         }
@@ -1628,6 +1659,7 @@ show_usage(char *name)
     printf("  --parit<y> o (=odd) | e (=even) | n (=none)\n");
     printf("  --<d>atabits 5 | 6 | 7 | 8\n");
     printf("  --sto<p>bits 1 | 2\n");
+    printf("  --<L>ine-delay <nsec>\n");
     printf("  --<e>scape <char>\n");
     printf("  --<n>o-escape\n");
     printf("  --e<c>ho\n");
@@ -1707,6 +1739,7 @@ parse_args(int argc, char *argv[])
         {"lower-dtr", no_argument, 0, 2},
         {"raise-rts", no_argument, 0, 3},
         {"raise-dtr", no_argument, 0, 4},
+        {"line-delay", required_argument, 0, 'L'},
         {"quiet", no_argument, 0, 'q'},
         {"help", no_argument, 0, 'h'},
         {0, 0, 0, 0}
@@ -1722,7 +1755,7 @@ parse_args(int argc, char *argv[])
         /* no default error messages printed. */
         opterr = 0;
 
-        c = getopt_long(argc, argv, "hirulcqXnv:s:r:e:f:b:y:d:p:g:t:x:",
+        c = getopt_long(argc, argv, "hirulcqXnv:s:r:e:f:b:y:d:p:g:t:x:L:",
                         longOptions, &optionIndex);
 
         if (c < 0)
@@ -1884,6 +1917,15 @@ parse_args(int argc, char *argv[])
         case 4:
             opts.raise_dtr = 1;
             break;
+        case 'L':
+            opts.line_delay.tv_nsec = strtol(optarg, &ep, 10);
+
+            /* Limit to 1 second */
+            if (!ep || *ep != '\0' || opts.line_delay.tv_nsec < 0 || opts.line_delay.tv_nsec >= 1000000000) {
+                fprintf(stderr, "Invalid --line-delay (must be between 0 and 999999999): %s\n", optarg);
+                r = -1;
+            }
+            break;
         case 'x':
             opts.exit_after = strtol(optarg, &ep, 10);
             if ( ! ep || *ep != '\0' || opts.exit_after < 0 ) {
@@ -1956,6 +1998,7 @@ parse_args(int argc, char *argv[])
     printf("parity is      : %s\n", parity_str[opts.parity]);
     printf("databits are   : %d\n", opts.databits);
     printf("stopbits are   : %d\n", opts.stopbits);
+    printf("linedelay is   : %ld ns\r\n", opts.line_delay.tv_nsec);
     if ( opts.noescape ) {
         printf("escape is      : none\n");
     } else {


### PR DESCRIPTION
Using '-L' we add the specified delay (in ns) after each line. This helps when you have no flow control and lose characters because of overflowing buffers. Especially when pasting long text.
